### PR TITLE
Add issue and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,92 @@
+name: Bug report
+about: Create a report to help us improve
+title: ""
+labels: ["bug"]
+assignees: ""
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before crearting an issue, make sure you read the [contributing guide](https://github.com/FIT3170-FY-Project-7/RABIT-COMMON/blob/main/CONTRIBUTING.md) and searched for similar issue.
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    id: steps_to_reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Steps to reproduce the behaviour
+      placeholder: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected_behaviour
+    attributes:
+      label: Expected behaviour
+      description: A clear and concise description of what you expected to happen.
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: OS
+      options:
+      - Windows
+      - macOS
+      - Linux
+      - Android
+      - iOS
+      - Other
+    validations:
+      required: true
+  - type: input
+    id: os_version
+    attributes:
+      label: OS version
+      description: Also include the OS name if you select 'Other' to the OS field.
+    validations:
+      required: true
+  - type: dropdown
+    id: browser
+    attributes:
+      label: Browser
+      options:
+        - Chrome
+        - Firefox
+        - Microsoft Edge
+        - Safari
+        - Brave
+        - Vivaldi
+        - Opera
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: browser_version
+    attributes:
+      label: Browser version
+      description: Also include the browser name if you select 'Other' to the browser field.
+    validations:
+      required: true
+  - type: input
+    id: device_model
+    attributes:
+      label: Device model
+    validations:
+      required: false
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,42 @@
+name: Feature request
+about: Suggest an idea for this project
+title: ""
+labels: ["enhancement"]
+assignees: ""
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before crearting an issue, make sure you read the [contributing guide](https://github.com/FIT3170-FY-Project-7/RABIT-COMMON/blob/main/CONTRIBUTING.md) and searched for similar issue.
+  - type: textarea
+    id: problem_related
+    attributes:
+      label: Is your feature request related to a problem? Please describe.
+      description: A clear and concise description of what the problem is.
+      placeholder: Ex. I'm always frustrated when [...]
+    validations:
+      required: false
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the solution you'd like
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe alternatives you've considered
+      description: A clear and concise description of any alternative solutions or features you've considered.
+    validations:
+      required: false
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here.
+    validations:
+      required: false
+
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,7 @@
 ---
 
 ### 📄 | Licensing
-> In order to be accepted and merged into RABIT, __each piece of code must be in public domain or released under [ISC license](https://github.com/FIT3170-FY-Project-7/RABIT-COMMON/blob/main/LICENSE.md)__.
+> In order to be accepted and merged into RABIT, __each piece of code must be released under [ISC license](https://github.com/FIT3170-FY-Project-7/RABIT-COMMON/blob/main/LICENSE.md) or a compatible license__.
 >
 > *Check **one** of the following options:*
 - [ ] I am the original author of this code and I am willing to release it under the ISC license.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,23 +1,30 @@
 <!--
-# Please follow the guide below
-- You will be asked some questions, please read them **carefully** and answer honestly
-- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
-- Use *Preview* tab to see how your pull request will actually look like.
+# Please follow the guide below:
+> You will be asked some questions, please read them carefully and answer honestly.
+> Check all relevant boxes relevant to your pull request ([ ] => [x]).
+> Use the preview tab to see what your pull request will actually look like.
 -->
 
-
-### Before submitting a pull request make sure you have:
-- [ ] At least skimmed through [contributing guidelines](https://github.com/FIT3170-FY-Project-7/RABIT-COMMON/blob/main/CONTRIBUTING.md)
-- [ ] Searched the bugtracker for similar pull requests
-
-### In order to be accepted and merged into RABIT each piece of code must be in public domain or released under [ISC license](https://github.com/FIT3170-FY-Project-7/RABIT-COMMON/blob/main/LICENSE.md). Check one of the following options:
-- [ ] I am the original author of this code and I am willing to release it under ISC license.
-- [ ] I am not the original author of this code but it is released under ISC license or a compatible license (provide reliable evidence)
+### 📋 | Pre-PR
+> Before submitting a pull request make sure you have:
+- [ ] Read the [contributing guidelines](https://github.com/FIT3170-FY-Project-7/RABIT-COMMON/blob/main/CONTRIBUTING.md).
+- [ ] Searched the bug tracker for similar pull requests.
 
 ---
 
-### Description of your pull request and other information
+### 📄 | Licensing
+> In order to be accepted and merged into RABIT, __each piece of code must be in public domain or released under [ISC license](https://github.com/FIT3170-FY-Project-7/RABIT-COMMON/blob/main/LICENSE.md)__.
+>
+> *Check **one** of the following options:*
+- [ ] I am the original author of this code and I am willing to release it under the ISC license.
+- [ ] I am not the original author of this code but it is released under the ISC license or a compatible license (please provide evidence).
 
-Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your pull request and is worded well enough to be understood. Provide as much **context and examples** as possible.
+---
 
-<!-- WRITE YOUR DESCRIPTION BELOW THIS COMMENT-->
+### ℹ️ | Description / Further Information
+> Explanation of __the purpose and effect__ of your *pull request* goes here.
+> 
+> Provide __context and examples__ as necessary.
+
+<!-- WRITE YOUR DESCRIPTION BELOW THIS COMMENT -->
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+<!--
+# Please follow the guide below
+- You will be asked some questions, please read them **carefully** and answer honestly
+- Put an `x` into all the boxes `[ ]` relevant to your *pull request* (like [x])
+- Use *Preview* tab to see how your pull request will actually look like.
+-->
+
+
+### Before submitting a pull request make sure you have:
+- [ ] At least skimmed through [contributing guidelines](https://github.com/FIT3170-FY-Project-7/RABIT-COMMON/blob/main/CONTRIBUTING.md)
+- [ ] Searched the bugtracker for similar pull requests
+
+### In order to be accepted and merged into RABIT each piece of code must be in public domain or released under [ISC license](https://github.com/FIT3170-FY-Project-7/RABIT-COMMON/blob/main/LICENSE.md). Check one of the following options:
+- [ ] I am the original author of this code and I am willing to release it under ISC license.
+- [ ] I am not the original author of this code but it is released under ISC license or a compatible license (provide reliable evidence)
+
+---
+
+### Description of your pull request and other information
+
+Explanation of your *pull request* in arbitrary form goes here. Please **make sure the description explains the purpose and effect** of your pull request and is worded well enough to be understood. Provide as much **context and examples** as possible.
+
+<!-- WRITE YOUR DESCRIPTION BELOW THIS COMMENT-->


### PR DESCRIPTION
Add an issue template for bug report and feature suggestion using GitHub forms which ensures consistent formatting for all issues.

Also created a pull request template based on the [yt-dlp PR template](https://github.com/yt-dlp/yt-dlp/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

note: I intentionally branched it from main as it shouldn't affect the code and so it can be applied immediately