### PR TITLE
Fix dependency issue for arm64/aarch64

### DIFF
--- a/docker/frontend.Dockerfile
+++ b/docker/frontend.Dockerfile
@@ -3,10 +3,11 @@
 
 # build
 FROM node:18-alpine AS builder
+#ENV CPPFLAGS="-DPNG_ARM_NEON_OPT=0"
 WORKDIR /rabit-frontend
 COPY ./RABIT-FRONTEND .
-# required for gifsicle 
-RUN apk add --no-cache autoconf automake file g++ libtool make nasm libpng-dev 
+# required for gifsicle
+RUN apk add --no-cache autoconf automake file g++ libtool make nasm libpng-dev bash
 RUN npm ci --save-dev
 RUN npm run build
 

--- a/docker/frontend.Dockerfile
+++ b/docker/frontend.Dockerfile
@@ -3,7 +3,7 @@
 
 # build
 FROM node:18-alpine AS builder
-#ENV CPPFLAGS="-DPNG_ARM_NEON_OPT=0"
+ENV CPPFLAGS="-DPNG_ARM_NEON_OPT=0"
 WORKDIR /rabit-frontend
 COPY ./RABIT-FRONTEND .
 # required for gifsicle


### PR DESCRIPTION
This patch fixes issues building on ARM-based platforms (e.g. Apple M1, Raspberry Pi)

More info: https://github.com/FIT3170-FY-Project-7/RABIT-FRONTEND/pull/22