### PR TITLE
Improve docker build time by rearranging build steps

### DIFF
--- a/docker/frontend.Dockerfile
+++ b/docker/frontend.Dockerfile
@@ -1,17 +1,20 @@
 # Dockerfile for RABIT frontend container.
 # Uses Node version 18 to build and nginx v1.x to run. OS is Alpine Linux
 
-# build
+# Install dependencies
 FROM node:18-alpine AS builder
-ENV CPPFLAGS="-DPNG_ARM_NEON_OPT=0"
 WORKDIR /rabit-frontend
-COPY ./RABIT-FRONTEND .
-# required for gifsicle
+ENV CPPFLAGS="-DPNG_ARM_NEON_OPT=0"
+COPY ./RABIT-FRONTEND/package.json .
+COPY ./RABIT-FRONTEND/package-lock.json .
 RUN apk add --no-cache autoconf automake file g++ libtool make nasm libpng-dev bash
 RUN npm ci --save-dev
+
+# Build
+COPY ./RABIT-FRONTEND .
 RUN npm run build
 
-# copy files to final container
+# Copy files to final container
 FROM nginx:1-alpine
 WORKDIR /rabit-frontend
 COPY --from=builder /rabit-frontend/dist /var/www/rabit-frontend


### PR DESCRIPTION
This PR improves docker build time by taking advantage of how it caches each step of the build. Basically it puts items that change less often (e.g. dependency install) before more frequently changed items (e.g. the build itself).

More info: https://vsupalov.com/5-tips-to-speed-up-docker-build/
