### PR TITLE
Add create_temp_user.sql to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       - "3306:3306"
     volumes:
       - db-data:/var/lib/mysql
+      # the filenames in the bind mount are prefixed with number so they're executed in that order
       - ./RABIT-BACKEND/database_schemas/DB_generation_schema.sql:/docker-entrypoint-initdb.d/01_DB_generation_schema.sql:ro
       - ./RABIT-BACKEND/database_schemas/create_temp_user.sql:/docker-entrypoint-initdb.d/02_create_temp_user.sql:ro
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,8 @@ services:
       - "3306:3306"
     volumes:
       - db-data:/var/lib/mysql
-      - ./RABIT-BACKEND/database_schemas/DB_generation_schema.sql:/docker-entrypoint-initdb.d/DB_generation_schema.sql:ro
+      - ./RABIT-BACKEND/database_schemas/DB_generation_schema.sql:/docker-entrypoint-initdb.d/01_DB_generation_schema.sql:ro
+      - ./RABIT-BACKEND/database_schemas/create_temp_user.sql:/docker-entrypoint-initdb.d/02_create_temp_user.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "mysqladmin ping"]
       interval: 1m30s


### PR DESCRIPTION
<!--
# Please follow the guide below:
> You will be asked some questions, please read them carefully and answer honestly.
> Check all relevant boxes relevant to your pull request ([ ] => [x]).
> Use the preview tab to see what your pull request will actually look like.
-->

### 📋 | Pre-PR
> Before submitting a pull request make sure you have:
- [x] Read the [contributing guidelines](https://github.com/FIT3170-FY-Project-7/RABIT-COMMON/blob/main/CONTRIBUTING.md).
- [x] Searched the bug tracker for similar pull requests.

---

### 📄 | Licensing
> In order to be accepted and merged into RABIT, __each piece of code must be released under [ISC license](https://github.com/FIT3170-FY-Project-7/RABIT-COMMON/blob/main/LICENSE.md) or a compatible license__.
>
> *Check **one** of the following options:*
- [ ] I am the original author of this code and I am willing to release it under the ISC license.
- [x] I am not the original author of this code but it is released under the ISC license or a compatible license (please provide evidence).

---

### ℹ️ | Description / Further Information
> Explanation of __the purpose and effect__ of your *pull request* goes here.
> 
> Provide __context and examples__ as necessary.

<!-- WRITE YOUR DESCRIPTION BELOW THIS COMMENT -->

Add `create_temp_user.sql` to docker-compose.yml as part of the init scripts to ensure that the temporary user has been properly created so the app is ready to use with just a single `docker-compose up`.

The bind mount names have numbers prefixed so they are executed in the correct order.
