### PR TITLE
Add docker-compose config only for database

### DIFF
--- a/db-docker-compose.yml
+++ b/db-docker-compose.yml
@@ -1,0 +1,27 @@
+# This compose file is for creating the db container ONLY.
+# it can be used if you want to use manual deployment for frontend and backend.
+
+services:
+  db:
+    image: mysql:8
+    command: --default-authentication-plugin=mysql_native_password
+    restart: unless-stopped
+    environment:
+      MYSQL_DATABASE: rabit
+      MYSQL_ROOT_PASSWORD: replace-this
+    ports:
+      - "3306:3306"
+    volumes:
+      - db-data:/var/lib/mysql
+      # the filenames in the bind mount are prefixed with number so they're executed in that order
+      - ./RABIT-BACKEND/database_schemas/DB_generation_schema.sql:/docker-entrypoint-initdb.d/01_DB_generation_schema.sql:ro
+      - ./RABIT-BACKEND/database_schemas/create_temp_user.sql:/docker-entrypoint-initdb.d/02_create_temp_user.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping"]
+      interval: 1m30s
+      timeout: 30s
+      retries: 5
+      start_period: 30s
+
+volumes:
+  db-data:


### PR DESCRIPTION
<!--
# Please follow the guide below:
> You will be asked some questions, please read them carefully and answer honestly.
> Check all relevant boxes relevant to your pull request by adding an x to the square brackets: ([ ] => [x]).
> Use the preview tab to see what your pull request will actually look like.
-->

## 📋 | Pre-PR

Before submitting a pull request make sure you have:

- [x] Read the [contributing guidelines](https://fit3170-fy-project-7.github.io/RABIT-DOCS/dev-guide/contributing.html).
- [x] Searched the bug tracker for similar pull requests.

<!--
Please ensure that you opened a pull request to the correct repository. Otherwise your PR may be closed or ignored.

Frontend: https://github.com/FIT3170-FY-Project-7/RABIT-FRONTEND
Backend: https://github.com/FIT3170-FY-Project-7/RABIT-BACKEND
Common: https://github.com/FIT3170-FY-Project-7/RABIT-COMMON
Documentation: https://github.com/FIT3170-FY-Project-7/RABIT-DOCS

If your PR spans over multiple repositories, open a separate PR in each of them and mention the PRs in the additional context section below.
-->

- [x] This PR is related to the code that is common to RABIT front- and backend and will be merged to the [RABIT-COMMON](https://github.com/FIT3170-FY-Project-7/RABIT-COMMON) repository.

---

## 📄 | Licensing

> In order to be accepted and merged into RABIT, **each piece of code must be released under [ISC license](https://github.com/FIT3170-FY-Project-7/RABIT-COMMON/blob/main/LICENSE.md) or a compatible license**.
>

*Check **one** of the following options:*

- [x] I am the original author of this code, and I am willing to release it under the ISC license.
- [ ] I am not the original author of this code, but it is released under the ISC license or a compatible license (please provide evidence).

---

## ℹ️ | Description / Further Information

> Explanation of __the purpose and effect__ of your *pull request* goes here.
>
> Provide __context and examples__ as necessary.

<!-- WRITE YOUR DESCRIPTION BELOW THIS COMMENT -->

Add a docker-compose config that will deploy the db container for those who want to use `npm run start` on frontend and backend but don't want to go through setting up MySQL.

- Up: `docker-compose -f db-docker-compose.yml up`
- Down: `docker-compose -f db-docker-compose.yml down`
- Down and remove volumes: `docker-compose -f db-docker-compose.yml down -v`

It's **very important** to pass `-f db-docker-compose.yml` when you want to deploy just `db` as it otherwise defaults to reading `docker-compose.yml` which will deploy the whole stack.

On the backend, `DB_HOST` environment variable must be set to `localhost` as technically the `db` container is exposing the conection to localhost, and if we put `db` then it will look at connection on hostname `db` and you'll get `getaddrinfo ENOTFOUND db`.